### PR TITLE
fixed RecExtElectrode docstring example etc.

### DIFF
--- a/LFPy/lfpcalc.py
+++ b/LFPy/lfpcalc.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """Copyright (C) 2012 Computational Neuroscience Group, NMBU.
 
 This program is free software: you can redistribute it and/or modify
@@ -19,12 +20,12 @@ import numpy as np
 def calc_lfp_linesource(cell, x=0., y=0., z=0., sigma=0.3,
                         r_limit=None, t_indices=None):
     """Calculate electric field potential using the line-source method, all
-    compartments treated as line sources, even soma.
+    compartments treated as line sources, including soma.
     
     Parameters
     ----------        
     cell: obj
-        LFPy.Cell or LFPy.TemplateCell instance
+        LFPy.Cell or LFPy.TemplateCell like instance
     x : float
         extracellular position, x-axis
     y : float
@@ -98,7 +99,7 @@ def calc_lfp_soma_as_point(cell, x=0., y=0., z=0., sigma=0.3,
     Parameters
     ----------
     cell: obj
-        `LFPy.Cell` or `LFPy.TemplateCell` instance
+        `LFPy.Cell` or `LFPy.TemplateCell` like instance
     x : float
         extracellular position, x-axis
     y : float
@@ -260,7 +261,7 @@ def calc_lfp_pointsource(cell, x=0, y=0, z=0, sigma=0.3,
     Parameters
     ----------
     cell: obj
-        LFPy.Cell or LFPy.TemplateCell instance
+        LFPy.Cell or LFPy.TemplateCell like instance
     x : float
         extracellular position, x-axis
     y : float

--- a/LFPy/lfpcalc.pyx
+++ b/LFPy/lfpcalc.pyx
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 '''Copyright (C) 2012 Computational Neuroscience Group, NMBU.
 
 This program is free software: you can redistribute it and/or modify
@@ -30,12 +31,12 @@ cpdef np.ndarray[DTYPE_t, ndim=1, negative_indices=False] calc_lfp_linesource(
                         r_limit=None,
                         t_indices=None):
     """Calculate electric field potential using the line-source method, all
-    compartments treated as line sources, even soma.
+    compartments treated as line sources, including soma.
 
     Parameters
     ----------
     cell: obj
-        LFPy.Cell or LFPy.TemplateCell instance
+        LFPy.Cell or LFPy.TemplateCell like instance
     x : float
         extracellular position, x-axis
     y : float
@@ -122,7 +123,7 @@ cpdef np.ndarray[DTYPE_t, ndim=1] calc_lfp_soma_as_point(cell,
     Parameters
     ----------
     cell: obj
-        `LFPy.Cell` or `LFPy.TemplateCell` instance
+        `LFPy.Cell` or `LFPy.TemplateCell` like instance
     x : float
         extracellular position, x-axis
     y : float
@@ -354,7 +355,7 @@ cpdef calc_lfp_pointsource(cell, double x=0, double y=0, double z=0,
     Parameters
     ----------
     cell: obj
-        LFPy.Cell or LFPy.TemplateCell instance
+        LFPy.Cell or LFPy.TemplateCell like instance
     x : float
         extracellular position, x-axis
     y : float


### PR DESCRIPTION
@torbjone 
I did some further docstring fixes, and removed color and marker args. For the method argument I think we should default now to `linesource` as that implementation was fixed earlier, and less deviations between the methods are now seen as a result. It is for example not captured what type of segment is the first one in the list of segment indices. For whatever reasons, people may simply define a stick with no soma, or make some dendrite the root section. 

If you merge this in, I will in turn merge your PR into LFPy:dev